### PR TITLE
docs: update and extend docs

### DIFF
--- a/packages/emeralt-assets/README.md
+++ b/packages/emeralt-assets/README.md
@@ -6,13 +6,13 @@ Emeralt logos and other assets
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/assets
+npm install @emeralt/assets
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/assets
+yarn add @emeralt/assets
 ```
 
 ## Logos

--- a/packages/emeralt-auth-inmemory/README.md
+++ b/packages/emeralt-auth-inmemory/README.md
@@ -6,13 +6,13 @@ Emeralt auth plugin to store users in memory
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/auth-inmemory
+npm install @emeralt/auth-inmemory
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/auth-inmemory
+yarn add @emeralt/auth-inmemory
 ```
 
 ## Usage

--- a/packages/emeralt-cli/README.md
+++ b/packages/emeralt-cli/README.md
@@ -6,13 +6,13 @@ Emeralt command-line interface
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/cli
+npm install --global @emeralt/cli
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/cli
+yarn global add @emeralt/cli
 ```
 
 ## Usage

--- a/packages/emeralt-database-cloud-firestore/README.md
+++ b/packages/emeralt-database-cloud-firestore/README.md
@@ -6,13 +6,13 @@ Emeralt database plugin to store packages in Google Cloud Firestore
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/database-cloud-firestore
+npm install @emeralt/database-cloud-firestore
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/database-cloud-firestore
+yarn add @emeralt/database-cloud-firestore
 ```
 
 ## Usage

--- a/packages/emeralt-database-inmemory/README.md
+++ b/packages/emeralt-database-inmemory/README.md
@@ -6,13 +6,13 @@ Emeralt database plugin to store packages in memory
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/database-inmemory
+npm install @emeralt/database-inmemory
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/database-inmemory
+yarn add @emeralt/database-inmemory
 ```
 
 ## Usage

--- a/packages/emeralt-database-mongodb/README.md
+++ b/packages/emeralt-database-mongodb/README.md
@@ -6,17 +6,38 @@ Emeralt database plugin to store packages in MongoDB
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/database-mongodb
+npm install @emeralt/database-mongodb
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/database-mognodb
+yarn add @emeralt/database-mongodb
 ```
 
 ## Usage
 
 ```ts
-new EmeraltDatabaseMongoDB()
+new EmeraltDatabaseMongoDB(options)
+```
+
+
+### Options
+
+```ts
+type Options = {
+  // mongodb connection URI
+  uri?: string
+
+  // indexing configuration
+  // by default, indexing is enabled (indexing property is undefined)
+  // but it can be disabled explicitly by setting indexing to false
+  indexing?:
+    | {
+        metadatas: boolean
+        versions: boolean
+        options?: IndexOptions
+      }
+    | false
+}
 ```

--- a/packages/emeralt-database-mongodb/src/index.ts
+++ b/packages/emeralt-database-mongodb/src/index.ts
@@ -8,7 +8,12 @@ import { MongoClient, Db, Collection, IndexOptions } from 'mongodb'
 import deepmerge from 'deepmerge'
 
 type Options = {
+  // mongodb connection URI
   uri?: string
+
+  // indexing configuration
+  // by default, indexing is enabled (indexing property is undefined)
+  // but it can be disabled explicitly by setting indexing to false
   indexing?:
     | {
         metadatas: boolean
@@ -20,10 +25,6 @@ type Options = {
 
 export const defaultOptions: Options = {
   uri: 'mongodb://localhost:27017/emeralt-test',
-
-  // indexing configuration
-  // by default, indexing is enabled (indexing property is undefined)
-  // but it can be enabled explicitly by setting indexing to false
   indexing: {
     metadatas: true,
     versions: true,

--- a/packages/emeralt-database-mongodb/test/indexes.test.ts
+++ b/packages/emeralt-database-mongodb/test/indexes.test.ts
@@ -51,19 +51,3 @@ test<IEmeraltDatabase>('indexing disable', async (t, dbc) => {
   t.false(await db.collection('versions').indexExists('name_1'))
   t.false(await db.collection('metadatas').indexExists('name_1'))
 })
-
-// test.serial('indexes', async (t) => {
-
-//   // @ts-ignore
-//   await EmeraltDatabaseMongoDB({
-//     indexing: {
-//       metadatas: false,
-//       versions: false,
-//     },
-//   })({})
-
-//   t.true(await db.collection('metadata').indexExists('name_1'))
-//   t.true(await db.collection('versions').indexExists('name_1'))
-
-//   db.dropDatabase()
-// })

--- a/packages/emeralt-database-redis/README.md
+++ b/packages/emeralt-database-redis/README.md
@@ -5,12 +5,12 @@ Emeralt database plugin to store packages in Redis
 
 Using npm:
 ```sh
-npm install --save-dev @emeralt/database-redis
+npm install @emeralt/database-redis
 ```
 
 or using yarn:
 ```sh
-yarn add --dev @emeralt/database-redis
+yarn add @emeralt/database-redis
 ```
 
 ## Usage

--- a/packages/emeralt-server/README.md
+++ b/packages/emeralt-server/README.md
@@ -8,13 +8,13 @@ Emeralt Node.js HTTP server module
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/server
+npm install @emeralt/server
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/server
+yarn add @emeralt/server
 ```
 
 ---

--- a/packages/emeralt-storage-gcs/README.md
+++ b/packages/emeralt-storage-gcs/README.md
@@ -6,13 +6,13 @@ Emeralt storage plugin to store package tarball in Google Cloud Storage
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/storage-gcs
+npm install @emeralt/storage-gcs
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/storage-gcs
+yarn add @emeralt/storage-gcs
 ```
 
 ## Usage

--- a/packages/emeralt-storage-inmemory/README.md
+++ b/packages/emeralt-storage-inmemory/README.md
@@ -6,13 +6,13 @@ Emeralt storage plugin to store package tarballs in memory
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/storage-inmemory
+npm install @emeralt/storage-inmemory
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/storage-inmemory
+yarn add @emeralt/storage-inmemory
 ```
 
 ## Usage

--- a/packages/emeralt-storage-localfs/README.md
+++ b/packages/emeralt-storage-localfs/README.md
@@ -6,13 +6,13 @@ Emeralt storage plugin to store package tarballs in local filesystem
 Using npm:
 
 ```sh
-npm install --save-dev @emeralt/storage-localfs
+npm install @emeralt/storage-localfs
 ```
 
 or using yarn:
 
 ```sh
-yarn add --dev @emeralt/storage-localfs
+yarn add @emeralt/storage-localfs
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 Emeralt is the NPM registry with focus on high extensibility, simplicity and clean codebase written fully in TypeScript. Highly inspired by Verdaccio. Why not Verdaccio? The idea is to write it from scratch, avoiding all architectural problems of old codebase.
 
 ### Status
-**Alpha**. Everything ~~might~~ **will** be changed.
+**Beta**
 
 ### Goals
 - High extensibility
@@ -20,7 +20,7 @@ Emeralt is the NPM registry with focus on high extensibility, simplicity and cle
 - Developer-frendly
 
 ### Contributions
-Wanted! See Issues and Contribution Guidelines. Feel free to contact me at `stackdumper@gmail.com`
+Wanted! See Issues. Feel free to contact me at `stackdumper@gmail.com`
 
 ---
 
@@ -39,6 +39,7 @@ Wanted! See Issues and Contribution Guidelines. Feel free to contact me at `stac
 
 - [`@emeralt/database-inmemory`](./packages/emeralt-database-inmemory)
 - [`@emeralt/database-redis`](./packages/emeralt-database-redis)
+- [`@emeralt/database-mongodb`](./packages/emeralt-database-mongodb)
 - [`@emeralt/database-cloud-firestore`](./packages/emeralt-database-cloud-firestore)
 
 ##### <sup>Storage plugins</sup>


### PR DESCRIPTION
Extend docs for `@emeralt/database-mongodb`, remove `--save-dev` and `--dev` from installation instructions.